### PR TITLE
feat: run a second suite like Playwright e2e with --adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Adapters**: `--adapter <name>` (`-a`) runs one adapter by name instead of auto-detecting,
+  and takes precedence over `adapter =` in `testx.toml`.
+- **Custom adapters**: an adapter with no detect rules is now opt-in — it never auto-detects
+  and only runs when named. This is how a second suite (Playwright e2e, smoke, contract tests)
+  lives beside a project's default suite.
+- **Custom adapters**: `report_file = "<path>"` parses the report a runner writes to disk
+  instead of stdout, for `pytest --junitxml`, `jest-junit`, `gotestsum --junitfile` and
+  `PLAYWRIGHT_JUNIT_OUTPUT_NAME`. Falls back to stdout when the file is absent.
 - **Workspace**: `testx workspace --exclude <dirs>` to skip directories during the scan.
   `WorkspaceConfig::skip_dirs` was honoured by the scanner but unreachable from the CLI.
 - **Adapters**: adapter overrides in `testx.toml` now accept a single alias segment, so
@@ -17,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JUnit parser**: each `<testsuite>` now owns only its own `<testcase>` elements. Runners
+  that emit one suite per file (Playwright, jest-junit, surefire) reported every test once
+  per suite, so a 5-test run showed up as 10.
+- **JUnit parser**: single-line documents — what `pytest --junitxml` and most JUnit writers
+  emit — are parsed instead of falling through to raw output, and `name=` no longer matches
+  the tail of `classname=`.
+- **Custom adapters**: an adapter with an empty `detect` matched every directory, because the
+  empty detect file joined to the project directory itself.
+- **Custom adapters**: a `detect` block with only `commands`, `env` or `content` rules never
+  matched; the file check vetoed it before the other rules ran.
 - **Exit code**: a runner that exits non-zero while every reported test passes is now a
   failure. Coverage thresholds (`pytest --cov-fail-under`), warnings-as-errors, plugin and
   collection errors, and timeouts were silently reported as success.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ testx -w                 # Watch mode — re-run on file changes
 testx --retries 3        # Retry failed tests 3 times
 testx --reporter github  # Activate GitHub Actions reporter
 testx --no-custom-adapters  # Disable custom adapter loading
+testx --adapter e2e         # Run a named adapter instead of auto-detecting
 testx run --filter "auth*"  # Filter tests by name pattern
 testx run --exclude "*slow" # Exclude tests matching pattern
 testx run --fail-fast       # Stop on first failure
@@ -357,6 +358,28 @@ search_depth = 2
 [[custom_adapter.detect.content]]
 file = "Makefile"
 contains = "test:"
+```
+
+### A second suite beside the default one
+
+An adapter with **no detect rules never auto-detects** — it only runs when you name it.
+That is how a slow or heavyweight suite (e2e, smoke, contract tests) lives in the same
+project as the fast one. Use `report_file` when the runner writes its machine-readable
+results to a file rather than stdout, which is the norm for `pytest --junitxml`,
+`jest-junit` and Playwright:
+
+```toml
+# testx            -> the project's own suite (vitest, pytest, cargo test, …)
+# testx --adapter e2e -> the Playwright suite
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
 ```
 
 ### Global adapters

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,7 @@ These flags work with any command.
 | Flag                   | Short | Type    | Default  | Description                                                                      |
 | ---------------------- | ----- | ------- | -------- | -------------------------------------------------------------------------------- |
 | `--path`               | `-p`  | PATH    | `.`      | Project directory to run in                                                      |
+| `--adapter`            | `-a`  | NAME    | —        | Run a specific adapter instead of auto-detecting (built-in or custom)            |
 | `--output`             | `-o`  | FORMAT  | `pretty` | Output format: `pretty`, `json`, `junit`, `tap`                                  |
 | `--slowest`            |       | N       | —        | Show N slowest tests at the end of the run                                       |
 | `--raw`                |       | —       | —        | Show raw output from the test runner (no formatting)                             |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -149,6 +149,7 @@ output = "lines"                 # How to parse output: json | junit | tap | lin
 confidence = 0.5                 # Detection confidence (0.0 – 1.0)
 check = "myfw --version"         # Verify the runner is installed before running
 working_dir = "tests"            # Run from this directory (relative to project root)
+report_file = "results.xml"      # Parse this file instead of stdout, if the runner writes one
 
 [custom_adapter.env]
 MY_VAR = "value"
@@ -162,6 +163,7 @@ MY_VAR = "value"
 - `output` — How testx parses the output (`lines` = no parsing, just pass through)
 - `confidence` — How confident testx should be when this adapter matches (higher = preferred over other matches)
 - `check` — A command that must succeed (exit code 0) for the adapter to be usable
+- `report_file` — Where the runner writes its report. Relative paths resolve against `working_dir`. testx parses this file when it exists and falls back to stdout when it doesn't.
 
 ### Advanced detection (multiple signals)
 
@@ -192,6 +194,32 @@ This adapter only activates when:
 3. The `CI` environment variable is set, AND
 4. The `Makefile` contains the string `test:`
 
+### Opt-in adapters (a second suite)
+
+An adapter with **no detect rules never auto-detects**. It stays out of the way until you
+ask for it by name, which is how a slow suite lives beside the fast one in the same project:
+
+```toml
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
+```
+
+```bash
+testx                  # the project's own suite (vitest, pytest, cargo test, …)
+testx --adapter e2e    # the Playwright suite
+```
+
+`report_file` matters here because Playwright's `webServer` logs share stdout with the
+report. Any runner that writes JUnit or JSON to a file — `pytest --junitxml`, `jest-junit`,
+`gotestsum --junitfile` — works the same way.
+
 ### Global custom adapters
 
 If you want an adapter available in **all** your projects (not just one), place `.toml` files in:
@@ -209,6 +237,9 @@ Each file can contain one or more `[[custom_adapter]]` blocks.
 ```bash
 # List all adapters (built-in + project + global custom)
 testx adapters
+
+# Run one adapter by name instead of auto-detecting
+testx --adapter e2e
 
 # Run tests but ignore all custom adapters
 testx --no-custom-adapters

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -107,6 +107,29 @@ file = "Makefile"
 contains = "test:"                    # File must contain this string
 ```
 
+### Opt-in adapters
+
+An adapter with **no detect rules never auto-detects** — it runs only when named. Use it
+for a second, heavier suite in the same project. `report_file` parses the report the
+runner writes to disk instead of stdout:
+
+```toml
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
+```
+
+```bash
+testx                  # the project's own suite
+testx --adapter e2e    # the Playwright suite
+```
+
 ### Global adapters
 
 To make an adapter available in **all** your projects, place `.toml` files in:
@@ -122,6 +145,9 @@ To make an adapter available in **all** your projects, place `.toml` files in:
 ```bash
 # List all registered adapters (built-in + project + global)
 testx adapters
+
+# Run one adapter by name instead of auto-detecting
+testx --adapter e2e
 
 # Disable custom adapter loading (use only built-in adapters)
 testx --no-custom-adapters

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,9 @@ pub struct CustomAdapterConfig {
     pub check: Option<String>,
     /// Working directory relative to project root
     pub working_dir: Option<String>,
+    /// Report file the runner writes, parsed instead of stdout when present.
+    /// Relative paths resolve against `working_dir`.
+    pub report_file: Option<String>,
     /// Environment variables to set
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -168,6 +171,19 @@ pub struct CustomDetectConfig {
     pub content: Vec<ContentMatch>,
     /// Subdirectory search depth for markers (0 = root only)
     pub search_depth: usize,
+}
+
+impl CustomDetectConfig {
+    /// Whether any detection rule is declared.
+    ///
+    /// An adapter without rules is opt-in: it never auto-detects and is only
+    /// reachable via `--adapter <name>` or `adapter = "<name>"` in testx.toml.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+            && self.commands.is_empty()
+            && self.env_vars.is_empty()
+            && self.content.is_empty()
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for CustomDetectConfig {
@@ -580,6 +596,27 @@ contains = "my-runner"
         assert_eq!(custom[0].detect.content[0].contains, "my-runner");
         assert_eq!(custom[0].check.as_deref(), Some("my-runner --version"));
         assert_eq!(custom[0].working_dir.as_deref(), Some("tests"));
+    }
+
+    #[test]
+    fn load_config_with_opt_in_custom_adapter() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("testx.toml"),
+            r#"
+[[custom_adapter]]
+name = "e2e"
+command = "npx"
+args = ["playwright", "test", "--reporter=junit"]
+output = "junit"
+report_file = "junit.xml"
+"#,
+        )
+        .unwrap();
+        let config = Config::load(dir.path());
+        let custom = config.custom_adapter.as_ref().unwrap();
+        assert_eq!(custom[0].report_file.as_deref(), Some("junit.xml"));
+        assert!(custom[0].detect.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use colored::Colorize;
 
+use testx::adapters::DetectionResult;
 use testx::{config::Config, detection, output};
 
 #[derive(ValueEnum, Clone, Default)]
@@ -90,6 +91,10 @@ struct Cli {
     /// Disable custom adapters defined in testx.toml or global config
     #[arg(long, global = true)]
     no_custom_adapters: bool,
+
+    /// Run a specific adapter by name instead of auto-detecting
+    #[arg(short = 'a', long, global = true)]
+    adapter: Option<String>,
 
     /// Extra arguments to pass through to the underlying test runner (after --)
     #[arg(last = true)]
@@ -288,6 +293,8 @@ fn run(cli: Cli) -> Result<()> {
                 for c in customs {
                     let detect_desc = if !c.detect.files.is_empty() {
                         c.detect.files.join(", ")
+                    } else if c.detect.is_empty() {
+                        format!("opt-in only — run with --adapter {}", c.name)
                     } else {
                         "custom detection".into()
                     };
@@ -1004,8 +1011,8 @@ args = []
             let retries = cli.retries.or(config.retries).unwrap_or(0);
             let fail_fast = fail_fast || config.fail_fast.unwrap_or(false);
 
-            // Resolve adapter override from config
-            let adapter_override = config.adapter.clone();
+            // Resolve adapter override: CLI --adapter > testx.toml adapter
+            let adapter_override = cli.adapter.clone().or_else(|| config.adapter.clone());
 
             // Resolve filter: CLI --filter > config filter.include
             let filter_include = filter.or_else(|| {
@@ -1132,17 +1139,21 @@ args = []
             }
 
             let detected = if let Some(ref override_name) = adapter_override {
-                // Find adapter by name override from config
+                // Find adapter by name override from CLI or testx.toml
                 let idx = engine.find_adapter(override_name).with_context(|| {
-                    format!("Unknown adapter '{}' in testx.toml", override_name)
-                })?;
-                let det = engine.adapter(idx).detect(&project_dir).with_context(|| {
                     format!(
-                        "Adapter '{}' does not detect a project at {}",
-                        override_name,
-                        project_dir.display()
+                        "Unknown adapter '{}'. Run 'testx adapters' to list them.",
+                        override_name
                     )
                 })?;
+                // An explicit pin is the answer, not a hint: adapters that
+                // deliberately never auto-detect are still runnable by name.
+                let adapter = engine.adapter(idx);
+                let det = adapter.detect(&project_dir).unwrap_or(DetectionResult {
+                    language: "Custom".to_string(),
+                    framework: adapter.name().to_string(),
+                    confidence: 1.0,
+                });
                 testx::detection::DetectedProject {
                     adapter_index: idx,
                     detection: det,

--- a/src/plugin/script_adapter.rs
+++ b/src/plugin/script_adapter.rs
@@ -58,6 +58,8 @@ pub struct ScriptAdapterConfig {
     pub parser: OutputParser,
     /// Working directory relative to project root (default: ".")
     pub working_dir: Option<String>,
+    /// Report file the runner writes; parsed instead of stdout when it exists.
+    pub report_file: Option<String>,
     /// Environment variables to set
     pub env: Vec<(String, String)>,
 }
@@ -73,6 +75,7 @@ impl ScriptAdapterConfig {
             args: Vec::new(),
             parser: OutputParser::Lines,
             working_dir: None,
+            report_file: None,
             env: Vec::new(),
         }
     }
@@ -95,6 +98,12 @@ impl ScriptAdapterConfig {
         self
     }
 
+    /// Set the report file to parse instead of stdout.
+    pub fn with_report_file(mut self, path: &str) -> Self {
+        self.report_file = Some(path.to_string());
+        self
+    }
+
     /// Add an environment variable.
     pub fn with_env(mut self, key: &str, value: &str) -> Self {
         self.env.push((key.to_string(), value.to_string()));
@@ -103,8 +112,9 @@ impl ScriptAdapterConfig {
 
     /// Check if this adapter detects at the given project directory.
     pub fn detect(&self, project_dir: &Path) -> bool {
-        let detect_path = project_dir.join(&self.detect_file);
-        if detect_path.exists() {
+        // An empty `detect_file` joins to `project_dir` itself, which always
+        // exists — that would make the adapter match every directory.
+        if !self.detect_file.is_empty() && project_dir.join(&self.detect_file).exists() {
             return true;
         }
 
@@ -175,6 +185,8 @@ pub struct ScriptTestAdapter {
     pub source: String,
     /// Enhanced detection config (content matching, command checks, env vars)
     detect_config: Option<crate::config::CustomDetectConfig>,
+    /// Directory the last command ran in, used to resolve a relative report file.
+    run_dir: std::sync::OnceLock<PathBuf>,
 }
 
 impl ScriptTestAdapter {
@@ -187,6 +199,7 @@ impl ScriptTestAdapter {
             is_global: false,
             source: "testx.toml".to_string(),
             detect_config: None,
+            run_dir: std::sync::OnceLock::new(),
         }
     }
 
@@ -215,6 +228,7 @@ impl ScriptTestAdapter {
             args: cfg.args.clone(),
             parser,
             working_dir: cfg.working_dir.clone(),
+            report_file: cfg.report_file.clone(),
             env,
         };
 
@@ -225,6 +239,7 @@ impl ScriptTestAdapter {
             is_global: false,
             source: "testx.toml".to_string(),
             detect_config: Some(cfg.detect.clone()),
+            run_dir: std::sync::OnceLock::new(),
         }
     }
 
@@ -251,6 +266,27 @@ impl ScriptTestAdapter {
         self.is_global = is_global;
         self
     }
+
+    /// Read the configured report file, if one is set and was produced.
+    ///
+    /// Runners that emit machine-readable results usually write them to a file
+    /// (`pytest --junitxml`, `jest-junit`, `PLAYWRIGHT_JUNIT_OUTPUT_NAME`), so
+    /// stdout alone is not parseable. Falls back to stdout when the file is
+    /// absent so a misconfigured path still shows the runner's own output.
+    fn read_report_file(&self) -> Option<String> {
+        let configured = self.config.report_file.as_ref()?;
+        let path = Path::new(configured);
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.run_dir
+                .get()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(path)
+        };
+        std::fs::read_to_string(path).ok()
+    }
 }
 
 /// Parse a parser name string into an OutputParser enum.
@@ -270,54 +306,44 @@ impl TestAdapter for ScriptTestAdapter {
     }
 
     fn detect(&self, project_dir: &Path) -> Option<DetectionResult> {
-        let detected = if let Some(ref dc) = self.detect_config {
-            // Enhanced detection: ALL configured checks must pass
+        let detected = match &self.detect_config {
+            // No rule at all: opt-in adapter, reachable only by name.
+            Some(dc) if dc.is_empty() => false,
+            Some(dc) => {
+                // Every configured check must pass. An absent check is not a
+                // veto, so a content-only or command-only rule still works.
+                let files_ok =
+                    dc.files.is_empty() || dc.files.iter().any(|f| project_dir.join(f).exists());
 
-            // Check files (at least one must exist)
-            let mut pass = if !dc.files.is_empty() {
-                dc.files.iter().any(|f| project_dir.join(f).exists())
-            } else {
-                // Fall back to basic file detection
-                self.config.detect(project_dir)
-            };
+                let commands_ok = files_ok
+                    && dc.commands.iter().all(|cmd_str| {
+                        let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+                        if parts.is_empty() {
+                            return false;
+                        }
+                        create_command(parts[0])
+                            .args(&parts[1..])
+                            .current_dir(project_dir)
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .status()
+                            .map(|s| s.success())
+                            .unwrap_or(false)
+                    });
 
-            // Check commands (must all succeed)
-            if pass && !dc.commands.is_empty() {
-                pass = dc.commands.iter().all(|cmd_str| {
-                    let parts: Vec<&str> = cmd_str.split_whitespace().collect();
-                    if parts.is_empty() {
-                        return false;
-                    }
-                    create_command(parts[0])
-                        .args(&parts[1..])
-                        .current_dir(project_dir)
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status()
-                        .map(|s| s.success())
-                        .unwrap_or(false)
-                });
+                let env_ok =
+                    commands_ok && dc.env_vars.iter().all(|var| std::env::var(var).is_ok());
+
+                env_ok
+                    && dc.content.iter().all(|cm| {
+                        let file_path = project_dir.join(&cm.file);
+                        std::fs::read_to_string(file_path)
+                            .map(|content| content.contains(&cm.contains))
+                            .unwrap_or(false)
+                    })
             }
-
-            // Check environment variables (all must be set)
-            if pass && !dc.env_vars.is_empty() {
-                pass = dc.env_vars.iter().all(|var| std::env::var(var).is_ok());
-            }
-
-            // Check content matches (all must match)
-            if pass && !dc.content.is_empty() {
-                pass = dc.content.iter().all(|cm| {
-                    let file_path = project_dir.join(&cm.file);
-                    std::fs::read_to_string(file_path)
-                        .map(|content| content.contains(&cm.contains))
-                        .unwrap_or(false)
-                });
-            }
-
-            pass
-        } else {
             // No enhanced config: use basic file detection only
-            self.config.detect(project_dir)
+            None => self.config.detect(project_dir),
         };
 
         if detected {
@@ -366,10 +392,15 @@ impl TestAdapter for ScriptTestAdapter {
             cmd.env(key, value);
         }
 
+        let _ = self.run_dir.set(working_dir);
+
         Ok(cmd)
     }
 
     fn parse_output(&self, stdout: &str, stderr: &str, exit_code: i32) -> TestRunResult {
+        if let Some(report) = self.read_report_file() {
+            return parse_script_output(&self.config.parser, &report, stderr, exit_code);
+        }
         parse_script_output(&self.config.parser, stdout, stderr, exit_code)
     }
 
@@ -546,18 +577,22 @@ fn parse_json_test(value: &serde_json::Value) -> Option<TestCase> {
 
 /// Parse JUnit XML output.
 fn parse_junit_output(stdout: &str, exit_code: i32) -> TestRunResult {
-    let mut suites = Vec::new();
-
-    // Find all <testsuite> blocks
-    for line in stdout.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("<testsuite")
-            && !trimmed.starts_with("<testsuites")
-            && let Some(suite) = parse_junit_suite_tag(trimmed, stdout)
-        {
-            suites.push(suite);
-        }
-    }
+    // Each <testsuite> owns only the <testcase> elements inside it. Runners
+    // that emit one suite per file (Playwright, jest-junit, surefire) would
+    // otherwise report every test once per suite.
+    let mut suites: Vec<TestSuite> = xml_elements(stdout, "testsuite")
+        .into_iter()
+        .filter_map(|(tag, body)| {
+            let tests = parse_junit_testcases(&body);
+            if tests.is_empty() {
+                return None;
+            }
+            Some(TestSuite {
+                name: extract_xml_attr(&tag, "name").unwrap_or_else(|| "tests".to_string()),
+                tests,
+            })
+        })
+        .collect();
 
     // If no suites found, try to parse <testcase> elements directly
     if suites.is_empty() {
@@ -581,82 +616,114 @@ fn parse_junit_output(stdout: &str, exit_code: i32) -> TestRunResult {
     }
 }
 
-fn parse_junit_suite_tag(tag: &str, full_output: &str) -> Option<TestSuite> {
-    let name = extract_xml_attr(tag, "name").unwrap_or_else(|| "tests".to_string());
-    let tests = parse_junit_testcases(full_output);
-    if tests.is_empty() {
-        return None;
-    }
-    Some(TestSuite { name, tests })
+fn parse_junit_testcases(xml: &str) -> Vec<TestCase> {
+    xml_elements(xml, "testcase")
+        .into_iter()
+        .map(|(tag, body)| {
+            let failure = xml_elements(&body, "failure")
+                .into_iter()
+                .chain(xml_elements(&body, "error"))
+                .next();
+
+            let (status, error) = match failure {
+                Some((tag, _)) => (
+                    TestStatus::Failed,
+                    Some(TestError {
+                        message: extract_xml_attr(&tag, "message")
+                            .unwrap_or_else(|| "Test failed".to_string()),
+                        location: None,
+                    }),
+                ),
+                None if !xml_elements(&body, "skipped").is_empty() => (TestStatus::Skipped, None),
+                None => (TestStatus::Passed, None),
+            };
+
+            TestCase {
+                name: extract_xml_attr(&tag, "name").unwrap_or_else(|| "unknown".to_string()),
+                status,
+                duration: extract_xml_attr(&tag, "time")
+                    .and_then(|t| t.parse::<f64>().ok())
+                    .map(duration_from_secs_safe)
+                    .unwrap_or(Duration::ZERO),
+                error,
+            }
+        })
+        .collect()
 }
 
-fn parse_junit_testcases(xml: &str) -> Vec<TestCase> {
-    let mut tests = Vec::new();
-    let lines: Vec<&str> = xml.lines().collect();
+/// Collect every `<name ...>` element in `xml` as `(open tag, inner body)`.
+///
+/// Scans by tag offset rather than by line so that single-line documents —
+/// what `pytest --junitxml` and most JUnit writers produce — parse the same as
+/// pretty-printed ones. Self-closing elements yield an empty body.
+fn xml_elements(xml: &str, name: &str) -> Vec<(String, String)> {
+    let open = format!("<{name}");
+    let close = format!("</{name}>");
+    let mut elements = Vec::new();
+    let mut cursor = 0;
 
-    let mut i = 0;
-    while i < lines.len() {
-        let trimmed = lines[i].trim();
-        if trimmed.starts_with("<testcase") {
-            let name = extract_xml_attr(trimmed, "name").unwrap_or_else(|| "unknown".to_string());
-            let time = extract_xml_attr(trimmed, "time")
-                .and_then(|t| t.parse::<f64>().ok())
-                .map(duration_from_secs_safe)
-                .unwrap_or(Duration::ZERO);
+    while let Some(offset) = xml[cursor..].find(&open) {
+        let start = cursor + offset;
+        let after_name = start + open.len();
 
-            // Check for failure/error/skipped in subsequent lines
-            let mut status = TestStatus::Passed;
-            let mut error = None;
-
-            if trimmed.ends_with("/>") {
-                // Self-closing, check for nested skipped/failure check
-                if trimmed.contains("<skipped") {
-                    status = TestStatus::Skipped;
-                }
-            } else {
-                // Look at following lines until </testcase>
-                let mut j = i + 1;
-                while j < lines.len() {
-                    let inner = lines[j].trim();
-                    if inner.starts_with("</testcase") {
-                        break;
-                    }
-                    if inner.starts_with("<failure") || inner.starts_with("<error") {
-                        status = TestStatus::Failed;
-                        let message = extract_xml_attr(inner, "message")
-                            .unwrap_or_else(|| "Test failed".to_string());
-                        error = Some(TestError {
-                            message,
-                            location: None,
-                        });
-                    }
-                    if inner.starts_with("<skipped") {
-                        status = TestStatus::Skipped;
-                    }
-                    j += 1;
-                }
-            }
-
-            tests.push(TestCase {
-                name,
-                status,
-                duration: time,
-                error,
-            });
+        // Reject prefix matches: `<testsuites` is not a `<testsuite`.
+        if !matches!(xml[after_name..].chars().next(), Some(c) if c.is_whitespace() || c == '>' || c == '/')
+        {
+            cursor = after_name;
+            continue;
         }
-        i += 1;
+
+        let Some(offset) = xml[after_name..].find('>') else {
+            break;
+        };
+        let tag_end = after_name + offset;
+        let tag = xml[start..=tag_end].to_string();
+
+        if tag.ends_with("/>") {
+            elements.push((tag, String::new()));
+            cursor = tag_end + 1;
+            continue;
+        }
+
+        let body_start = tag_end + 1;
+        let (body, next) = match xml[body_start..].find(&close) {
+            Some(offset) => (
+                xml[body_start..body_start + offset].to_string(),
+                body_start + offset + close.len(),
+            ),
+            None => (xml[body_start..].to_string(), xml.len()),
+        };
+        elements.push((tag, body));
+        cursor = next;
     }
 
-    tests
+    elements
 }
 
 /// Extract an XML attribute value from an element tag.
 fn extract_xml_attr(tag: &str, attr: &str) -> Option<String> {
     let search = format!("{attr}=\"");
-    let start = tag.find(&search)? + search.len();
-    let rest = &tag[start..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
+    let mut from = 0;
+
+    while let Some(offset) = tag[from..].find(&search) {
+        let start = from + offset;
+        // `name=` must not match the tail of `classname=`.
+        let delimited = start == 0
+            || tag[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_whitespace() || c == '<');
+        let value_start = start + search.len();
+
+        if delimited {
+            let rest = &tag[value_start..];
+            let end = rest.find('"')?;
+            return Some(rest[..end].to_string());
+        }
+        from = value_start;
+    }
+
+    None
 }
 
 /// Parse TAP (Test Anything Protocol) output.
@@ -1437,6 +1504,84 @@ mod tests {
         assert_eq!(extract_xml_attr("<test>", "name"), None);
     }
 
+    #[test]
+    fn xml_attr_ignores_a_longer_attribute_with_the_same_suffix() {
+        assert_eq!(
+            extract_xml_attr(r#"<testcase classname="Foo" name="bar">"#, "name"),
+            Some("bar".into())
+        );
+    }
+
+    // ─── Opt-in adapters & report files ─────────────────────────────────
+
+    fn custom_config(name: &str, command: &str) -> crate::config::CustomAdapterConfig {
+        toml::from_str(&format!(
+            "name = \"{name}\"\ncommand = \"{command}\"\noutput = \"junit\"\n"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn adapter_without_detect_rules_never_auto_detects() {
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = ScriptTestAdapter::from_custom_config(&custom_config("e2e", "echo"));
+        assert!(adapter.detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn adapter_with_content_only_rule_detects() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Makefile"), "test:\n\techo hi\n").unwrap();
+
+        let cfg: crate::config::CustomAdapterConfig = toml::from_str(
+            r#"
+name = "make-test"
+command = "make test"
+[[detect.content]]
+file = "Makefile"
+contains = "test:"
+"#,
+        )
+        .unwrap();
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        assert!(adapter.detect(dir.path()).is_some());
+    }
+
+    #[test]
+    fn report_file_is_parsed_instead_of_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("junit.xml"),
+            r#"<testsuite name="e2e"><testcase name="login" time="0.5"/></testsuite>"#,
+        )
+        .unwrap();
+
+        let mut cfg = custom_config("e2e", "echo");
+        cfg.report_file = Some("junit.xml".into());
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        adapter.build_command(dir.path(), &[]).unwrap();
+
+        let result = adapter.parse_output("Running 1 test using 1 worker", "", 0);
+        assert_eq!(result.total_passed(), 1);
+        assert_eq!(result.suites[0].tests[0].name, "login");
+    }
+
+    #[test]
+    fn missing_report_file_falls_back_to_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = custom_config("e2e", "echo");
+        cfg.report_file = Some("never-written.xml".into());
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        adapter.build_command(dir.path(), &[]).unwrap();
+
+        let result = adapter.parse_output(
+            r#"<testsuite name="from-stdout"><testcase name="t" time="0.1"/></testsuite>"#,
+            "",
+            0,
+        );
+        assert_eq!(result.suites[0].name, "from-stdout");
+    }
+
     // ─── Fallback Result Tests ──────────────────────────────────────────
 
     #[test]
@@ -1780,8 +1925,33 @@ mod tests {
   </testsuite>
 </testsuites>"#;
         let result = parse_junit_output(xml, 0);
-        // Note: current parser finds testcases regardless of suite nesting
-        assert!(result.total_tests() >= 2);
+        // Each suite owns only its own testcases — no cross-suite duplication.
+        assert_eq!(result.total_tests(), 2);
+        assert_eq!(result.suites.len(), 2);
+        assert_eq!(result.suites[0].name, "s1");
+        assert_eq!(result.suites[0].tests[0].name, "t1");
+        assert_eq!(result.suites[1].name, "s2");
+        assert_eq!(result.suites[1].tests[0].name, "t2");
+    }
+
+    #[test]
+    fn parse_junit_single_line_document() {
+        // What pytest --junitxml and most JUnit writers actually emit.
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" tests="2"><testcase classname="test_a" name="passes" time="0.01"/><testcase classname="test_a" name="fails" time="0.02"><failure message="assert 1 == 2">trace</failure></testcase></testsuite></testsuites>"#;
+        let result = parse_junit_output(xml, 1);
+        assert_eq!(result.total_tests(), 2);
+        assert_eq!(result.total_failed(), 1);
+        assert_eq!(result.suites[0].name, "pytest");
+        assert_eq!(result.suites[0].tests[1].name, "fails");
+    }
+
+    #[test]
+    fn parse_junit_reads_name_not_classname() {
+        // Maven surefire puts classname first; `name=` must not match the tail
+        // of `classname=`.
+        let xml = r#"<testsuite name="s"><testcase classname="com.example.Foo" name="the_test" time="0.5"/></testsuite>"#;
+        let result = parse_junit_output(xml, 0);
+        assert_eq!(result.suites[0].tests[0].name, "the_test");
     }
 
     #[test]
@@ -2148,6 +2318,7 @@ mod tests {
             confidence: 0.7,
             check: Some("bazel --version".into()),
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2178,6 +2349,7 @@ mod tests {
             confidence: 0.5,
             check: None,
             working_dir: Some("src".into()),
+            report_file: None,
             env,
         };
 
@@ -2209,6 +2381,7 @@ mod tests {
             confidence: 0.6,
             check: None,
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2240,6 +2413,7 @@ mod tests {
             confidence: 0.6,
             check: None,
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 

--- a/tests/integration/custom_adapter.rs
+++ b/tests/integration/custom_adapter.rs
@@ -54,3 +54,144 @@ fn run_without_framework_errors_cleanly() {
         "Should show helpful error message"
     );
 }
+
+/// A custom adapter with no detect rules is opt-in: invisible to detection,
+/// runnable by name. This is how a second suite (e2e, smoke, contract tests)
+/// lives beside the project's default one.
+#[test]
+fn opt_in_adapter_runs_only_when_named() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+[[custom_adapter]]
+name = "e2e"
+command = "echo"
+args = ["PASS login_flow"]
+output = "lines"
+"#,
+    )
+    .unwrap();
+
+    let detected = Command::cargo_bin("testx")
+        .unwrap()
+        .args(["detect", "--path", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&detected.stdout).contains("No test framework detected"),
+        "opt-in adapter must not hijack detection"
+    );
+
+    let run = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "e2e",
+        ])
+        .output()
+        .unwrap();
+    assert!(run.status.success());
+    assert!(String::from_utf8_lossy(&run.stdout).contains("login_flow"));
+}
+
+#[test]
+fn unknown_adapter_name_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("README.md"), "# Empty").unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "cobol",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!result.status.success());
+    assert!(String::from_utf8_lossy(&result.stderr).contains("Unknown adapter 'cobol'"));
+}
+
+/// `--adapter` beats `adapter = ` in testx.toml, so a repo can pin its default
+/// suite and still run the other one on demand.
+#[test]
+fn cli_adapter_overrides_config_adapter() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"fake\"").unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+adapter = "Rust"
+
+[[custom_adapter]]
+name = "smoke"
+command = "echo"
+args = ["PASS smoke_check"]
+output = "lines"
+"#,
+    )
+    .unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "smoke",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(result.status.success());
+    assert!(String::from_utf8_lossy(&result.stdout).contains("smoke_check"));
+}
+
+/// Runners that only write machine-readable results to a file (pytest
+/// --junitxml, jest-junit, PLAYWRIGHT_JUNIT_OUTPUT_NAME) are parsed from it.
+#[test]
+fn report_file_is_parsed_instead_of_stdout() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("junit.xml"),
+        r#"<testsuites><testsuite name="e2e"><testcase name="checkout" time="1.5"/><testcase name="refund" time="0.5"><failure message="timeout"/></testcase></testsuite></testsuites>"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+[[custom_adapter]]
+name = "e2e"
+command = "echo"
+args = ["Running 2 tests using 1 worker"]
+output = "junit"
+report_file = "junit.xml"
+"#,
+    )
+    .unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "e2e",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(!result.status.success(), "one testcase failed: {stdout}");
+    assert!(stdout.contains("checkout"), "{stdout}");
+    assert!(stdout.contains("timeout"), "{stdout}");
+}


### PR DESCRIPTION
Some projects have a second suite that shouldn't auto-detect — e2e, smoke, contract tests. There was no way to declare one: a `[[custom_adapter]]` either fought the built-in adapter for detection, or with an empty `detect` hijacked every directory.

- `--adapter <name>` runs one adapter by name, beating `adapter =` in testx.toml
- a custom adapter with no detect rules is opt-in — it only runs when named
- `report_file` parses the report a runner writes to disk instead of stdout

```toml
# testx               -> vitest
# testx --adapter e2e -> playwright
[[custom_adapter]]
name = "e2e"
command = "npm"
args = ["run", "test:e2e", "--", "--reporter=list,junit"]
output = "junit"
report_file = "playwright-junit.xml"
```

Wiring it up surfaced three JUnit parser bugs, fixed here too: every `<testsuite>` got a copy of every `<testcase>` (a 5-test Playwright run reported 10), single-line XML fell through to raw output, and `name=` matched the tail of `classname=`.

Tested against a real Playwright suite (84 tests, 5 spec files). `cargo test` 1114 + 33 + 25 green, clippy and fmt clean.
