### PR TITLE
fix: report real test names and stop silently shrinking runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Adapters**: `--adapter <name>` (`-a`) runs one adapter by name instead of auto-detecting,
+  and takes precedence over `adapter =` in `testx.toml`.
+- **Custom adapters**: an adapter with no detect rules is now opt-in — it never auto-detects
+  and only runs when named. This is how a second suite (Playwright e2e, smoke, contract tests)
+  lives beside a project's default suite.
+- **Custom adapters**: `report_file = "<path>"` parses the report a runner writes to disk
+  instead of stdout, for `pytest --junitxml`, `jest-junit`, `gotestsum --junitfile` and
+  `PLAYWRIGHT_JUNIT_OUTPUT_NAME`. Falls back to stdout when the file is absent.
 - **Workspace**: `testx workspace --exclude <dirs>` to skip directories during the scan.
   `WorkspaceConfig::skip_dirs` was honoured by the scanner but unreachable from the CLI.
 - **Adapters**: adapter overrides in `testx.toml` now accept a single alias segment, so
@@ -17,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JUnit parser**: each `<testsuite>` now owns only its own `<testcase>` elements. Runners
+  that emit one suite per file (Playwright, jest-junit, surefire) reported every test once
+  per suite, so a 5-test run showed up as 10.
+- **JUnit parser**: single-line documents — what `pytest --junitxml` and most JUnit writers
+  emit — are parsed instead of falling through to raw output, and `name=` no longer matches
+  the tail of `classname=`.
+- **Custom adapters**: an adapter with an empty `detect` matched every directory, because the
+  empty detect file joined to the project directory itself.
+- **Custom adapters**: a `detect` block with only `commands`, `env` or `content` rules never
+  matched; the file check vetoed it before the other rules ran.
 - **Exit code**: a runner that exits non-zero while every reported test passes is now a
   failure. Coverage thresholds (`pytest --cov-fail-under`), warnings-as-errors, plugin and
   collection errors, and timeouts were silently reported as success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Custom adapters**: `report_file = "<path>"` parses the report a runner writes to disk
   instead of stdout, for `pytest --junitxml`, `jest-junit`, `gotestsum --junitfile` and
   `PLAYWRIGHT_JUNIT_OUTPUT_NAME`. Falls back to stdout when the file is absent.
+- **Custom adapters**: `output = "pattern"` reads a runner's ordinary output line by line
+  using `[custom_adapter.pattern]`. The parser existed but no configuration reached it.
+- **JavaScript**: projects whose `package.json` defines a `test` script but no recognised
+  framework now run through `npm test`, which covers `node --test`, tap, uvu, jasmine and
+  anything else a project scripts itself. TAP output is parsed per test.
 - **Workspace**: `testx workspace --exclude <dirs>` to skip directories during the scan.
   `WorkspaceConfig::skip_dirs` was honoured by the scanner but unreachable from the CLI.
 - **Adapters**: adapter overrides in `testx.toml` now accept a single alias segment, so
@@ -25,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Python**: passing any extra argument dropped `-v`, so pytest printed bare dots and every
+  test was reported under an invented name (`test_1`, `failed_test_2`). Verbosity is now kept
+  unless the caller sets it, which restores real names for `testx -- --cov`.
+- **Go**: passing any extra argument dropped both `-v` and `./...`, so `testx -- -race`
+  silently tested only the root package. Both are now kept unless the caller supplies them.
+- **Python**: a packaging manifest alone (`pyproject.toml`, `setup.py`, `requirements.txt`)
+  was enough to claim a project at ~67% confidence and then run `unittest` over a library
+  with no tests. Detection now requires a test directory, test files or a test config.
+- **Python**: workspace members inherit the pytest configuration from the workspace root, the
+  same way pytest resolves its rootdir. `uv`/Poetry monorepo members were previously run with
+  `python -m unittest`.
+- **Python**: `unittest` verbose output is parsed per test, including `skipped`,
+  `expected failure` and both the pre- and post-3.11 parenthesised forms.
 - **JUnit parser**: each `<testsuite>` now owns only its own `<testcase>` elements. Runners
   that emit one suite per file (Playwright, jest-junit, surefire) reported every test once
   per suite, so a 5-test run showed up as 10.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ testx -w                 # Watch mode — re-run on file changes
 testx --retries 3        # Retry failed tests 3 times
 testx --reporter github  # Activate GitHub Actions reporter
 testx --no-custom-adapters  # Disable custom adapter loading
+testx --adapter e2e         # Run a named adapter instead of auto-detecting
 testx run --filter "auth*"  # Filter tests by name pattern
 testx run --exclude "*slow" # Exclude tests matching pattern
 testx run --fail-fast       # Stop on first failure
@@ -357,6 +358,28 @@ search_depth = 2
 [[custom_adapter.detect.content]]
 file = "Makefile"
 contains = "test:"
+```
+
+### A second suite beside the default one
+
+An adapter with **no detect rules never auto-detects** — it only runs when you name it.
+That is how a slow or heavyweight suite (e2e, smoke, contract tests) lives in the same
+project as the fast one. Use `report_file` when the runner writes its machine-readable
+results to a file rather than stdout, which is the norm for `pytest --junitxml`,
+`jest-junit` and Playwright:
+
+```toml
+# testx            -> the project's own suite (vitest, pytest, cargo test, …)
+# testx --adapter e2e -> the Playwright suite
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
 ```
 
 ### Global adapters

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | **Rust**                    | cargo test                    | —                     |
 | **Go**                      | go test                       | —                     |
 | **Python**                  | pytest, unittest, Django      | uv, poetry, pdm, venv |
-| **JavaScript / TypeScript** | Jest, Vitest, Mocha, AVA, Bun | npm, pnpm, yarn, bun  |
+| **JavaScript / TypeScript** | Jest, Vitest, Mocha, AVA, Bun, `node --test`, or any `npm test` script | npm, pnpm, yarn, bun  |
 | **Java / Kotlin**           | Maven Surefire, Gradle        | mvn, gradle           |
 | **C / C++**                 | Google Test, CTest, Meson     | cmake, meson          |
 | **Ruby**                    | RSpec, Minitest               | bundler               |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,7 @@ These flags work with any command.
 | Flag                   | Short | Type    | Default  | Description                                                                      |
 | ---------------------- | ----- | ------- | -------- | -------------------------------------------------------------------------------- |
 | `--path`               | `-p`  | PATH    | `.`      | Project directory to run in                                                      |
+| `--adapter`            | `-a`  | NAME    | —        | Run a specific adapter instead of auto-detecting (built-in or custom)            |
 | `--output`             | `-o`  | FORMAT  | `pretty` | Output format: `pretty`, `json`, `junit`, `tap`                                  |
 | `--slowest`            |       | N       | —        | Show N slowest tests at the end of the run                                       |
 | `--raw`                |       | —       | —        | Show raw output from the test runner (no formatting)                             |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -149,6 +149,7 @@ output = "lines"                 # How to parse output: json | junit | tap | lin
 confidence = 0.5                 # Detection confidence (0.0 – 1.0)
 check = "myfw --version"         # Verify the runner is installed before running
 working_dir = "tests"            # Run from this directory (relative to project root)
+report_file = "results.xml"      # Parse this file instead of stdout, if the runner writes one
 
 [custom_adapter.env]
 MY_VAR = "value"
@@ -162,6 +163,7 @@ MY_VAR = "value"
 - `output` — How testx parses the output (`lines` = no parsing, just pass through)
 - `confidence` — How confident testx should be when this adapter matches (higher = preferred over other matches)
 - `check` — A command that must succeed (exit code 0) for the adapter to be usable
+- `report_file` — Where the runner writes its report. Relative paths resolve against `working_dir`. testx parses this file when it exists and falls back to stdout when it doesn't.
 
 ### Advanced detection (multiple signals)
 
@@ -192,6 +194,32 @@ This adapter only activates when:
 3. The `CI` environment variable is set, AND
 4. The `Makefile` contains the string `test:`
 
+### Opt-in adapters (a second suite)
+
+An adapter with **no detect rules never auto-detects**. It stays out of the way until you
+ask for it by name, which is how a slow suite lives beside the fast one in the same project:
+
+```toml
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
+```
+
+```bash
+testx                  # the project's own suite (vitest, pytest, cargo test, …)
+testx --adapter e2e    # the Playwright suite
+```
+
+`report_file` matters here because Playwright's `webServer` logs share stdout with the
+report. Any runner that writes JUnit or JSON to a file — `pytest --junitxml`, `jest-junit`,
+`gotestsum --junitfile` — works the same way.
+
 ### Global custom adapters
 
 If you want an adapter available in **all** your projects (not just one), place `.toml` files in:
@@ -209,6 +237,9 @@ Each file can contain one or more `[[custom_adapter]]` blocks.
 ```bash
 # List all adapters (built-in + project + global custom)
 testx adapters
+
+# Run one adapter by name instead of auto-detecting
+testx --adapter e2e
 
 # Run tests but ignore all custom adapters
 testx --no-custom-adapters

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -165,6 +165,29 @@ MY_VAR = "value"
 - `check` — A command that must succeed (exit code 0) for the adapter to be usable
 - `report_file` — Where the runner writes its report. Relative paths resolve against `working_dir`. testx parses this file when it exists and falls back to stdout when it doesn't.
 
+### Parsing arbitrary output
+
+When a runner has no machine-readable format, `output = "pattern"` reads its
+ordinary lines. Patterns are literal text with `(.*)` capture groups and `.*`
+wildcards — not full regular expressions.
+
+```toml
+[[custom_adapter]]
+name = "bats"
+command = "bats"
+args = ["tests/"]
+output = "pattern"
+
+[custom_adapter.pattern]
+pass = "ok (.*)"
+fail = "not ok (.*)"
+skip = "ok (.*) # skip"
+name_group = 1        # 1-indexed capture group holding the test name
+```
+
+Lines that match nothing are ignored; if no line matches at all, testx falls
+back to a single result driven by the exit code.
+
 ### Advanced detection (multiple signals)
 
 For more precise detection, use a `[detect]` table with multiple conditions:

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -107,6 +107,29 @@ file = "Makefile"
 contains = "test:"                    # File must contain this string
 ```
 
+### Opt-in adapters
+
+An adapter with **no detect rules never auto-detects** — it runs only when named. Use it
+for a second, heavier suite in the same project. `report_file` parses the report the
+runner writes to disk instead of stdout:
+
+```toml
+[[custom_adapter]]
+name = "e2e"
+command = "npm"
+args = ["run", "test:e2e", "--", "--reporter=list,junit"]
+output = "junit"
+report_file = "playwright-junit.xml"
+
+[custom_adapter.env]
+PLAYWRIGHT_JUNIT_OUTPUT_NAME = "playwright-junit.xml"
+```
+
+```bash
+testx                  # the project's own suite
+testx --adapter e2e    # the Playwright suite
+```
+
 ### Global adapters
 
 To make an adapter available in **all** your projects, place `.toml` files in:
@@ -122,6 +145,9 @@ To make an adapter available in **all** your projects, place `.toml` files in:
 ```bash
 # List all registered adapters (built-in + project + global)
 testx adapters
+
+# Run one adapter by name instead of auto-detecting
+testx --adapter e2e
 
 # Disable custom adapter loading (use only built-in adapters)
 testx --no-custom-adapters

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -130,6 +130,25 @@ testx                  # the project's own suite
 testx --adapter e2e    # the Playwright suite
 ```
 
+### Parsing arbitrary output
+
+Runners with no machine-readable format are read line by line with
+`output = "pattern"`. Patterns are literal text with `(.*)` capture groups and
+`.*` wildcards — not full regular expressions.
+
+```toml
+[[custom_adapter]]
+name = "bats"
+command = "bats"
+args = ["tests/"]
+output = "pattern"
+
+[custom_adapter.pattern]
+pass = "ok (.*)"
+fail = "not ok (.*)"
+name_group = 1
+```
+
 ### Global adapters
 
 To make an adapter available in **all** your projects, place `.toml` files in:

--- a/src/adapters/go.rs
+++ b/src/adapters/go.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 
-use super::util::{combined_output, duration_from_secs_safe, ensure_non_empty};
+use super::util::{combined_output, duration_from_secs_safe, ensure_non_empty, sets_verbosity};
 use super::{
     ConfidenceScore, DetectionResult, TestAdapter, TestCase, TestRunResult, TestStatus, TestSuite,
 };
@@ -69,9 +69,13 @@ impl TestAdapter for GoAdapter {
         let mut cmd = Command::new("go");
         cmd.arg("test");
 
-        if extra_args.is_empty() {
+        if !extra_args.iter().any(|a| sets_verbosity(a)) {
             cmd.arg("-v"); // verbose for parsing individual tests
-            cmd.arg("./..."); // all packages
+        }
+        // Without an explicit package list `go test` only builds the current
+        // directory, so extra flags must not silently shrink the run.
+        if !extra_args.iter().any(|a| is_go_package_arg(a)) {
+            cmd.arg("./...");
         }
 
         for arg in extra_args {
@@ -196,6 +200,20 @@ impl TestAdapter for GoAdapter {
 
 /// Maximum recursion depth for Go test file discovery.
 const MAX_GO_SCAN_DEPTH: usize = 20;
+
+/// Whether an argument names Go packages rather than being a flag or a flag value.
+///
+/// `go test -race` alone tests only the current directory, so testx keeps
+/// `./...` unless the user named the packages themselves. Matching only
+/// path-shaped arguments keeps flag values like `-run TestFoo` out of it.
+fn is_go_package_arg(arg: &str) -> bool {
+    arg == "all" || arg == "." || arg.starts_with("./") || arg.starts_with('/') || {
+        // An import path such as example.com/pkg/... — dotted host, then a slash.
+        let mut parts = arg.splitn(2, '/');
+        let host = parts.next().unwrap_or_default();
+        parts.next().is_some() && host.contains('.')
+    }
+}
 
 fn find_test_files_recursive(dir: &Path) -> bool {
     find_test_files_recursive_inner(dir, 0)
@@ -469,5 +487,38 @@ FAIL	github.com/user/pkg	0.001s
         std::fs::write(dir.path().join("main.go"), "package main\n").unwrap();
         let adapter = GoAdapter::new();
         assert!(adapter.detect(dir.path()).is_none());
+    }
+
+    fn args_for(extra: &[&str]) -> Vec<String> {
+        let dir = tempfile::tempdir().unwrap();
+        let extra: Vec<String> = extra.iter().map(|s| s.to_string()).collect();
+        GoAdapter::new()
+            .build_command(dir.path(), &extra)
+            .unwrap()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn extra_flags_do_not_shrink_the_run() {
+        // `go test -race` alone would only build the current directory.
+        let args = args_for(&["-race"]);
+        assert!(args.contains(&"-v".to_string()), "{args:?}");
+        assert!(args.contains(&"./...".to_string()), "{args:?}");
+        assert!(args.contains(&"-race".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn a_flag_value_is_not_mistaken_for_a_package() {
+        let args = args_for(&["-run", "TestFoo"]);
+        assert!(args.contains(&"./...".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn explicit_packages_replace_the_default() {
+        let args = args_for(&["./pkg/..."]);
+        assert_eq!(args.iter().filter(|a| *a == "./...").count(), 0, "{args:?}");
+        assert!(args.contains(&"./pkg/...".to_string()), "{args:?}");
     }
 }

--- a/src/adapters/javascript.rs
+++ b/src/adapters/javascript.rs
@@ -108,8 +108,33 @@ impl JavaScriptAdapter {
             return Some("ava");
         }
 
+        // Anything else with a real `test` script: node --test, tap, uvu, jasmine,
+        // karma, a shell script. `npm test` is the project's own answer for how
+        // to run them, so use it rather than refusing to detect.
+        if has_test_script(&content) {
+            return Some("npm-script");
+        }
+
         None
     }
+}
+
+/// Whether package.json defines a `test` script that actually runs something.
+///
+/// `npm init` writes a placeholder that only exits 1; treating it as a suite
+/// would make every JavaScript project look testable.
+fn has_test_script(package_json: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(package_json) else {
+        return false;
+    };
+    let Some(script) = value
+        .get("scripts")
+        .and_then(|s| s.get("test"))
+        .and_then(|t| t.as_str())
+    else {
+        return false;
+    };
+    !script.trim().is_empty() && !script.contains("no test specified")
 }
 
 impl TestAdapter for JavaScriptAdapter {
@@ -184,6 +209,19 @@ impl TestAdapter for JavaScriptAdapter {
             "ava" => {
                 cmd = build_js_runner_cmd(pkg_manager, "ava");
             }
+            "npm-script" => {
+                // Delegate to whatever the project already defined.
+                let runner = if pkg_manager == "npx" {
+                    "npm"
+                } else {
+                    pkg_manager
+                };
+                cmd = Command::new(runner);
+                cmd.args(["run", "test"]);
+                if !extra_args.is_empty() {
+                    cmd.arg("--");
+                }
+            }
             _ => {
                 cmd = build_js_runner_cmd(pkg_manager, "jest");
             }
@@ -203,6 +241,20 @@ impl TestAdapter for JavaScriptAdapter {
 
     fn parse_output(&self, stdout: &str, stderr: &str, exit_code: i32) -> TestRunResult {
         let combined = strip_ansi(&combined_output(stdout, stderr));
+
+        // `node --test`, tap and tape emit TAP once stdout is not a terminal.
+        if combined
+            .lines()
+            .any(|l| l.trim_start().starts_with("TAP version"))
+        {
+            return crate::plugin::script_adapter::parse_script_output(
+                &crate::plugin::script_adapter::OutputParser::Tap,
+                &combined,
+                "",
+                exit_code,
+            );
+        }
+
         let failure_messages = parse_jest_failures(&combined);
         let mut suites: Vec<TestSuite> = Vec::new();
         let mut current_suite = String::new();
@@ -1097,5 +1149,55 @@ Time:        0.5 s
         let adapter = JavaScriptAdapter::new();
         let det = adapter.detect(dir.path()).unwrap();
         assert_eq!(det.framework, "ava");
+    }
+
+    #[test]
+    fn detect_falls_back_to_the_test_script() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts":{"test":"node --test"}}"#,
+        )
+        .unwrap();
+        let adapter = JavaScriptAdapter::new();
+        assert_eq!(adapter.detect(dir.path()).unwrap().framework, "npm-script");
+
+        let args: Vec<String> = adapter
+            .build_command(dir.path(), &[])
+            .unwrap()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(args, vec!["run", "test"]);
+    }
+
+    #[test]
+    fn npm_init_placeholder_is_not_a_suite() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"scripts":{"test":"echo \"Error: no test specified\" && exit 1"}}"#,
+        )
+        .unwrap();
+        assert!(JavaScriptAdapter::new().detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn tap_output_is_parsed() {
+        // `node --test` switches to TAP as soon as stdout is not a terminal.
+        let stdout = "\
+TAP version 13
+# Subtest: adds
+ok 1 - adds
+# Subtest: fails
+not ok 2 - fails
+ok 3 - later # SKIP
+1..3
+";
+        let result = JavaScriptAdapter::new().parse_output(stdout, "", 1);
+        assert_eq!(result.total_passed(), 1);
+        assert_eq!(result.total_failed(), 1);
+        assert_eq!(result.total_skipped(), 1);
+        assert_eq!(result.suites[0].tests[0].name, "adds");
     }
 }

--- a/src/adapters/python.rs
+++ b/src/adapters/python.rs
@@ -4,10 +4,15 @@ use std::time::Duration;
 
 use anyhow::Result;
 
-use super::util::{combined_output, duration_from_secs_safe};
+use super::util::{
+    combined_output, duration_from_secs_safe, has_marker_in_subdirs, sets_verbosity,
+};
 use super::{
     ConfidenceScore, DetectionResult, TestAdapter, TestCase, TestRunResult, TestStatus, TestSuite,
 };
+
+/// How far up the tree to look for a workspace-level pytest configuration.
+const MAX_ANCESTOR_LOOKUP: usize = 5;
 
 pub struct PythonAdapter;
 
@@ -24,42 +29,53 @@ impl PythonAdapter {
 
     /// Check if pytest is the test framework
     fn is_pytest(project_dir: &Path) -> bool {
-        // Check for pytest-specific files/configs
-        let markers = ["pytest.ini", ".pytest_cache", "conftest.py"];
-        for m in &markers {
-            if project_dir.join(m).exists() {
+        if Self::has_pytest_markers(project_dir) {
+            return true;
+        }
+
+        // Monorepo members (uv/poetry workspaces) keep the pytest config at the
+        // workspace root, which is also how pytest itself picks its rootdir.
+        project_dir
+            .ancestors()
+            .skip(1)
+            .take(MAX_ANCESTOR_LOOKUP)
+            .any(Self::has_strict_pytest_markers)
+    }
+
+    /// Pytest evidence in this directory alone.
+    fn has_pytest_markers(project_dir: &Path) -> bool {
+        if Self::has_strict_pytest_markers(project_dir) {
+            return true;
+        }
+
+        // A loose mention of pytest anywhere in pyproject.toml (a dependency,
+        // a tool section) is enough locally but too weak to inherit.
+        let pyproject = project_dir.join("pyproject.toml");
+        pyproject.exists()
+            && std::fs::read_to_string(&pyproject)
+                .map(|c| c.contains("pytest"))
+                .unwrap_or(false)
+    }
+
+    /// Configuration that unambiguously declares pytest.
+    fn has_strict_pytest_markers(dir: &Path) -> bool {
+        for m in ["pytest.ini", ".pytest_cache", "conftest.py"] {
+            if dir.join(m).exists() {
                 return true;
             }
         }
 
-        // Check pyproject.toml for pytest config
-        let pyproject = project_dir.join("pyproject.toml");
-        if pyproject.exists()
-            && let Ok(content) = std::fs::read_to_string(&pyproject)
-            && (content.contains("[tool.pytest") || content.contains("pytest"))
-        {
-            return true;
-        }
+        let file_contains = |file: &str, needle: &str| {
+            let path = dir.join(file);
+            path.exists()
+                && std::fs::read_to_string(&path)
+                    .map(|c| c.contains(needle))
+                    .unwrap_or(false)
+        };
 
-        // Check setup.cfg
-        let setup_cfg = project_dir.join("setup.cfg");
-        if setup_cfg.exists()
-            && let Ok(content) = std::fs::read_to_string(&setup_cfg)
-            && content.contains("[tool:pytest]")
-        {
-            return true;
-        }
-
-        // Check tox.ini
-        let tox_ini = project_dir.join("tox.ini");
-        if tox_ini.exists()
-            && let Ok(content) = std::fs::read_to_string(&tox_ini)
-            && content.contains("[pytest]")
-        {
-            return true;
-        }
-
-        false
+        file_contains("pyproject.toml", "[tool.pytest")
+            || file_contains("setup.cfg", "[tool:pytest]")
+            || file_contains("tox.ini", "[pytest]")
     }
 
     /// Check if Django is present
@@ -125,6 +141,18 @@ impl TestAdapter for PythonAdapter {
             return None;
         }
 
+        let has_test_dir = project_dir.join("tests").is_dir() || project_dir.join("test").is_dir();
+
+        // A packaging manifest alone is not a test suite. Without this a plain
+        // library gets claimed at ~67% confidence and then "runs" no tests.
+        if !Self::is_pytest(project_dir)
+            && !Self::is_django(project_dir)
+            && !has_test_dir
+            && !has_test_files(project_dir)
+        {
+            return None;
+        }
+
         let framework = if Self::is_pytest(project_dir) {
             "pytest"
         } else if Self::is_django(project_dir) {
@@ -135,7 +163,6 @@ impl TestAdapter for PythonAdapter {
 
         let is_pytest = framework == "pytest";
         let is_django = framework == "django";
-        let has_test_dir = project_dir.join("tests").is_dir() || project_dir.join("test").is_dir();
         let has_lock = project_dir.join("poetry.lock").exists()
             || project_dir.join("Pipfile.lock").exists()
             || project_dir.join("uv.lock").exists()
@@ -193,8 +220,10 @@ impl TestAdapter for PythonAdapter {
             cmd.arg("-m").arg("unittest");
         }
 
-        // Add verbose flag for better output parsing (pytest)
-        if is_pytest && extra_args.is_empty() {
+        // Verbose output is what makes per-test names parseable — without it both
+        // runners print bare dots and only the summary survives. Django is
+        // excluded because its `-v` takes a required level argument.
+        if !is_django && !extra_args.iter().any(|a| sets_verbosity(a)) {
             cmd.arg("-v");
         }
 
@@ -219,6 +248,24 @@ impl TestAdapter for PythonAdapter {
 
         for line in combined.lines() {
             let trimmed = line.trim();
+
+            // unittest verbose output: "test_name (pkg.module.Class) ... ok"
+            if let Some((suite_name, test_name, status)) = parse_unittest_line(trimmed) {
+                if suite_name != current_suite_name && !tests.is_empty() {
+                    suites.push(TestSuite {
+                        name: current_suite_name.clone(),
+                        tests: std::mem::take(&mut tests),
+                    });
+                }
+                current_suite_name = suite_name;
+                tests.push(TestCase {
+                    name: test_name,
+                    status,
+                    duration: Duration::from_millis(0),
+                    error: None,
+                });
+                continue;
+            }
 
             // pytest verbose output: "test_file.py::TestClass::test_name PASSED"
             // or: "test_file.py::test_name PASSED"
@@ -288,6 +335,45 @@ impl TestAdapter for PythonAdapter {
             raw_exit_code: exit_code,
         }
     }
+}
+
+/// Parse a unittest verbose line: `test_name (pkg.module.Class.test_name) ... ok`.
+///
+/// Python 3.11+ repeats the method inside the parentheses, older releases stop
+/// at the class. Returns `(suite, test, status)`.
+fn parse_unittest_line(line: &str) -> Option<(String, String, TestStatus)> {
+    let (head, status_str) = line.split_once(" ... ")?;
+    let (test_name, qualified) = head.split_once(" (")?;
+    let qualified = qualified.strip_suffix(')')?;
+
+    if test_name.is_empty()
+        || !test_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+
+    let status = match status_str.trim() {
+        "ok" => TestStatus::Passed,
+        s if s.starts_with("FAIL") || s.starts_with("ERROR") => TestStatus::Failed,
+        s if s.starts_with("unexpected success") => TestStatus::Failed,
+        s if s.starts_with("skipped") || s.starts_with("expected failure") => TestStatus::Skipped,
+        _ => return None,
+    };
+
+    let suite = qualified
+        .strip_suffix(&format!(".{test_name}"))
+        .unwrap_or(qualified);
+
+    Some((suite.to_string(), test_name.to_string(), status))
+}
+
+/// Whether the project contains anything that looks like a Python test module.
+fn has_test_files(project_dir: &Path) -> bool {
+    has_marker_in_subdirs(project_dir, 3, |name| {
+        name.ends_with(".py") && (name.starts_with("test_") || name.ends_with("_test.py"))
+    })
 }
 
 /// Parse a pytest verbose output line like "tests/test_foo.py::test_bar PASSED"
@@ -717,6 +803,7 @@ tests/test_math.py::test_setup ERROR
     fn detect_pipfile_project() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("Pipfile"), "[packages]\n").unwrap();
+        std::fs::create_dir(dir.path().join("tests")).unwrap();
         let adapter = PythonAdapter::new();
         let det = adapter.detect(dir.path()).unwrap();
         assert_eq!(det.language, "Python");
@@ -731,9 +818,113 @@ tests/test_math.py::test_setup ERROR
             "from setuptools import setup\n",
         )
         .unwrap();
+        std::fs::write(dir.path().join("test_thing.py"), "import unittest\n").unwrap();
         let adapter = PythonAdapter::new();
         let det = adapter.detect(dir.path()).unwrap();
         assert_eq!(det.framework, "unittest");
-        assert!(det.confidence < 0.6);
+        assert!(det.confidence < 0.7);
+    }
+
+    #[test]
+    fn packaging_manifest_without_tests_is_not_a_test_project() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            "[project]\nname = \"lib\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/lib.py"),
+            "def add(a, b):\n    return a + b\n",
+        )
+        .unwrap();
+
+        assert!(PythonAdapter::new().detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn workspace_member_inherits_pytest_from_the_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join("pyproject.toml"),
+            "[tool.pytest.ini_options]\ntestpaths = [\"services\"]\n",
+        )
+        .unwrap();
+
+        let member = root.path().join("services/api");
+        std::fs::create_dir_all(member.join("tests")).unwrap();
+        std::fs::write(
+            member.join("pyproject.toml"),
+            "[project]\nname = \"api\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            member.join("tests/test_api.py"),
+            "def test_ok():\n    pass\n",
+        )
+        .unwrap();
+
+        let det = PythonAdapter::new().detect(&member).unwrap();
+        assert_eq!(det.framework, "pytest");
+    }
+
+    #[test]
+    fn verbose_flag_survives_extra_args() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pytest.ini"), "[pytest]\n").unwrap();
+        let adapter = PythonAdapter::new();
+
+        let cmd = adapter
+            .build_command(dir.path(), &["--cov".to_string()])
+            .unwrap();
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"-v".to_string()), "{args:?}");
+        assert!(args.contains(&"--cov".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn explicit_quiet_is_not_overridden() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pytest.ini"), "[pytest]\n").unwrap();
+        let adapter = PythonAdapter::new();
+
+        let cmd = adapter
+            .build_command(dir.path(), &["-q".to_string()])
+            .unwrap();
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(!args.contains(&"-v".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn parses_unittest_verbose_lines() {
+        let output = "\
+test_adds (tests.test_calc.CalcTest.test_adds) ... ok
+test_breaks (tests.test_calc.CalcTest.test_breaks) ... FAIL
+test_later (tests.test_calc.CalcTest.test_later) ... skipped 'later'
+test_known_bad (tests.test_calc.CalcTest.test_known_bad) ... expected failure
+";
+        let result = PythonAdapter::new().parse_output(output, "", 1);
+        assert_eq!(result.total_tests(), 4);
+        assert_eq!(result.total_passed(), 1);
+        assert_eq!(result.total_failed(), 1);
+        assert_eq!(result.total_skipped(), 2);
+        assert_eq!(result.suites[0].name, "tests.test_calc.CalcTest");
+        assert_eq!(result.suites[0].tests[0].name, "test_adds");
+    }
+
+    #[test]
+    fn parses_unittest_lines_from_older_pythons() {
+        // Pre-3.11 stops at the class name inside the parentheses.
+        let output = "test_adds (tests.test_calc.CalcTest) ... ok\n";
+        let result = PythonAdapter::new().parse_output(output, "", 0);
+        assert_eq!(result.suites[0].name, "tests.test_calc.CalcTest");
+        assert_eq!(result.suites[0].tests[0].name, "test_adds");
     }
 }

--- a/src/adapters/util.rs
+++ b/src/adapters/util.rs
@@ -119,6 +119,18 @@ pub struct SummaryPatterns {
     pub skipped: &'static [&'static str],
 }
 
+/// Whether a user-supplied argument already decides the runner's verbosity.
+///
+/// Adapters inject a verbose flag so per-test names are parseable; they must
+/// not do so when the user has already asked for a specific level, and must
+/// not silently drop it just because other arguments were passed.
+pub fn sets_verbosity(arg: &str) -> bool {
+    let arg = arg.split('=').next().unwrap_or(arg);
+    matches!(arg, "--verbose" | "--quiet" | "--verbosity" | "-quiet")
+        || (arg.starts_with("-v") && arg.chars().skip(1).all(|c| c == 'v'))
+        || (arg.starts_with("-q") && arg.chars().skip(1).all(|c| c == 'q'))
+}
+
 /// Check if any file matching `predicate` exists in immediate subdirectories of `dir`.
 ///
 /// This enables detection of projects where the build/config file is one or two
@@ -824,5 +836,27 @@ mod tests {
     #[test]
     fn count_pattern_none() {
         assert_eq!(count_pattern("hello world", "FAIL"), 0);
+    }
+
+    #[test]
+    fn verbosity_flags_are_recognised() {
+        for arg in [
+            "-v",
+            "-vv",
+            "--verbose",
+            "-q",
+            "-qq",
+            "--quiet",
+            "--verbosity=2",
+        ] {
+            assert!(sets_verbosity(arg), "{arg} should count as verbosity");
+        }
+    }
+
+    #[test]
+    fn other_flags_are_not_verbosity() {
+        for arg in ["--cov", "-x", "-k", "--tb=short", "-race", "--version"] {
+            assert!(!sets_verbosity(arg), "{arg} should not count as verbosity");
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,9 +149,31 @@ pub struct CustomAdapterConfig {
     /// Report file the runner writes, parsed instead of stdout when present.
     /// Relative paths resolve against `working_dir`.
     pub report_file: Option<String>,
+    /// Line patterns for `output = "pattern"`.
+    #[serde(alias = "regex")]
+    pub pattern: Option<CustomPatternConfig>,
     /// Environment variables to set
     #[serde(default)]
     pub env: HashMap<String, String>,
+}
+
+/// Line patterns for the `pattern` output parser.
+///
+/// Patterns are literal text with `(.*)` capture groups and `.*` wildcards —
+/// not full regular expressions.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct CustomPatternConfig {
+    /// Pattern matching a line that reports a passing test
+    pub pass: String,
+    /// Pattern matching a line that reports a failing test
+    pub fail: String,
+    /// Pattern matching a line that reports a skipped test
+    pub skip: Option<String>,
+    /// 1-indexed capture group holding the test name
+    pub name_group: Option<usize>,
+    /// 1-indexed capture group holding the duration in milliseconds
+    pub duration_group: Option<usize>,
 }
 
 /// Detection configuration for custom adapters.

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,9 @@ pub struct CustomAdapterConfig {
     pub check: Option<String>,
     /// Working directory relative to project root
     pub working_dir: Option<String>,
+    /// Report file the runner writes, parsed instead of stdout when present.
+    /// Relative paths resolve against `working_dir`.
+    pub report_file: Option<String>,
     /// Environment variables to set
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -168,6 +171,19 @@ pub struct CustomDetectConfig {
     pub content: Vec<ContentMatch>,
     /// Subdirectory search depth for markers (0 = root only)
     pub search_depth: usize,
+}
+
+impl CustomDetectConfig {
+    /// Whether any detection rule is declared.
+    ///
+    /// An adapter without rules is opt-in: it never auto-detects and is only
+    /// reachable via `--adapter <name>` or `adapter = "<name>"` in testx.toml.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+            && self.commands.is_empty()
+            && self.env_vars.is_empty()
+            && self.content.is_empty()
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for CustomDetectConfig {
@@ -580,6 +596,27 @@ contains = "my-runner"
         assert_eq!(custom[0].detect.content[0].contains, "my-runner");
         assert_eq!(custom[0].check.as_deref(), Some("my-runner --version"));
         assert_eq!(custom[0].working_dir.as_deref(), Some("tests"));
+    }
+
+    #[test]
+    fn load_config_with_opt_in_custom_adapter() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("testx.toml"),
+            r#"
+[[custom_adapter]]
+name = "e2e"
+command = "npx"
+args = ["playwright", "test", "--reporter=junit"]
+output = "junit"
+report_file = "junit.xml"
+"#,
+        )
+        .unwrap();
+        let config = Config::load(dir.path());
+        let custom = config.custom_adapter.as_ref().unwrap();
+        assert_eq!(custom[0].report_file.as_deref(), Some("junit.xml"));
+        assert!(custom[0].detect.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use colored::Colorize;
 
+use testx::adapters::DetectionResult;
 use testx::{config::Config, detection, output};
 
 #[derive(ValueEnum, Clone, Default)]
@@ -90,6 +91,10 @@ struct Cli {
     /// Disable custom adapters defined in testx.toml or global config
     #[arg(long, global = true)]
     no_custom_adapters: bool,
+
+    /// Run a specific adapter by name instead of auto-detecting
+    #[arg(short = 'a', long, global = true)]
+    adapter: Option<String>,
 
     /// Extra arguments to pass through to the underlying test runner (after --)
     #[arg(last = true)]
@@ -288,6 +293,8 @@ fn run(cli: Cli) -> Result<()> {
                 for c in customs {
                     let detect_desc = if !c.detect.files.is_empty() {
                         c.detect.files.join(", ")
+                    } else if c.detect.is_empty() {
+                        format!("opt-in only — run with --adapter {}", c.name)
                     } else {
                         "custom detection".into()
                     };
@@ -1004,8 +1011,8 @@ args = []
             let retries = cli.retries.or(config.retries).unwrap_or(0);
             let fail_fast = fail_fast || config.fail_fast.unwrap_or(false);
 
-            // Resolve adapter override from config
-            let adapter_override = config.adapter.clone();
+            // Resolve adapter override: CLI --adapter > testx.toml adapter
+            let adapter_override = cli.adapter.clone().or_else(|| config.adapter.clone());
 
             // Resolve filter: CLI --filter > config filter.include
             let filter_include = filter.or_else(|| {
@@ -1132,17 +1139,21 @@ args = []
             }
 
             let detected = if let Some(ref override_name) = adapter_override {
-                // Find adapter by name override from config
+                // Find adapter by name override from CLI or testx.toml
                 let idx = engine.find_adapter(override_name).with_context(|| {
-                    format!("Unknown adapter '{}' in testx.toml", override_name)
-                })?;
-                let det = engine.adapter(idx).detect(&project_dir).with_context(|| {
                     format!(
-                        "Adapter '{}' does not detect a project at {}",
-                        override_name,
-                        project_dir.display()
+                        "Unknown adapter '{}'. Run 'testx adapters' to list them.",
+                        override_name
                     )
                 })?;
+                // An explicit pin is the answer, not a hint: adapters that
+                // deliberately never auto-detect are still runnable by name.
+                let adapter = engine.adapter(idx);
+                let det = adapter.detect(&project_dir).unwrap_or(DetectionResult {
+                    language: "Custom".to_string(),
+                    framework: adapter.name().to_string(),
+                    confidence: 1.0,
+                });
                 testx::detection::DetectedProject {
                     adapter_index: idx,
                     detection: det,

--- a/src/plugin/script_adapter.rs
+++ b/src/plugin/script_adapter.rs
@@ -58,6 +58,8 @@ pub struct ScriptAdapterConfig {
     pub parser: OutputParser,
     /// Working directory relative to project root (default: ".")
     pub working_dir: Option<String>,
+    /// Report file the runner writes; parsed instead of stdout when it exists.
+    pub report_file: Option<String>,
     /// Environment variables to set
     pub env: Vec<(String, String)>,
 }
@@ -73,6 +75,7 @@ impl ScriptAdapterConfig {
             args: Vec::new(),
             parser: OutputParser::Lines,
             working_dir: None,
+            report_file: None,
             env: Vec::new(),
         }
     }
@@ -95,6 +98,12 @@ impl ScriptAdapterConfig {
         self
     }
 
+    /// Set the report file to parse instead of stdout.
+    pub fn with_report_file(mut self, path: &str) -> Self {
+        self.report_file = Some(path.to_string());
+        self
+    }
+
     /// Add an environment variable.
     pub fn with_env(mut self, key: &str, value: &str) -> Self {
         self.env.push((key.to_string(), value.to_string()));
@@ -103,8 +112,9 @@ impl ScriptAdapterConfig {
 
     /// Check if this adapter detects at the given project directory.
     pub fn detect(&self, project_dir: &Path) -> bool {
-        let detect_path = project_dir.join(&self.detect_file);
-        if detect_path.exists() {
+        // An empty `detect_file` joins to `project_dir` itself, which always
+        // exists — that would make the adapter match every directory.
+        if !self.detect_file.is_empty() && project_dir.join(&self.detect_file).exists() {
             return true;
         }
 
@@ -175,6 +185,8 @@ pub struct ScriptTestAdapter {
     pub source: String,
     /// Enhanced detection config (content matching, command checks, env vars)
     detect_config: Option<crate::config::CustomDetectConfig>,
+    /// Directory the last command ran in, used to resolve a relative report file.
+    run_dir: std::sync::OnceLock<PathBuf>,
 }
 
 impl ScriptTestAdapter {
@@ -187,6 +199,7 @@ impl ScriptTestAdapter {
             is_global: false,
             source: "testx.toml".to_string(),
             detect_config: None,
+            run_dir: std::sync::OnceLock::new(),
         }
     }
 
@@ -215,6 +228,7 @@ impl ScriptTestAdapter {
             args: cfg.args.clone(),
             parser,
             working_dir: cfg.working_dir.clone(),
+            report_file: cfg.report_file.clone(),
             env,
         };
 
@@ -225,6 +239,7 @@ impl ScriptTestAdapter {
             is_global: false,
             source: "testx.toml".to_string(),
             detect_config: Some(cfg.detect.clone()),
+            run_dir: std::sync::OnceLock::new(),
         }
     }
 
@@ -251,6 +266,27 @@ impl ScriptTestAdapter {
         self.is_global = is_global;
         self
     }
+
+    /// Read the configured report file, if one is set and was produced.
+    ///
+    /// Runners that emit machine-readable results usually write them to a file
+    /// (`pytest --junitxml`, `jest-junit`, `PLAYWRIGHT_JUNIT_OUTPUT_NAME`), so
+    /// stdout alone is not parseable. Falls back to stdout when the file is
+    /// absent so a misconfigured path still shows the runner's own output.
+    fn read_report_file(&self) -> Option<String> {
+        let configured = self.config.report_file.as_ref()?;
+        let path = Path::new(configured);
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.run_dir
+                .get()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(path)
+        };
+        std::fs::read_to_string(path).ok()
+    }
 }
 
 /// Parse a parser name string into an OutputParser enum.
@@ -270,54 +306,44 @@ impl TestAdapter for ScriptTestAdapter {
     }
 
     fn detect(&self, project_dir: &Path) -> Option<DetectionResult> {
-        let detected = if let Some(ref dc) = self.detect_config {
-            // Enhanced detection: ALL configured checks must pass
+        let detected = match &self.detect_config {
+            // No rule at all: opt-in adapter, reachable only by name.
+            Some(dc) if dc.is_empty() => false,
+            Some(dc) => {
+                // Every configured check must pass. An absent check is not a
+                // veto, so a content-only or command-only rule still works.
+                let files_ok =
+                    dc.files.is_empty() || dc.files.iter().any(|f| project_dir.join(f).exists());
 
-            // Check files (at least one must exist)
-            let mut pass = if !dc.files.is_empty() {
-                dc.files.iter().any(|f| project_dir.join(f).exists())
-            } else {
-                // Fall back to basic file detection
-                self.config.detect(project_dir)
-            };
+                let commands_ok = files_ok
+                    && dc.commands.iter().all(|cmd_str| {
+                        let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+                        if parts.is_empty() {
+                            return false;
+                        }
+                        create_command(parts[0])
+                            .args(&parts[1..])
+                            .current_dir(project_dir)
+                            .stdout(std::process::Stdio::null())
+                            .stderr(std::process::Stdio::null())
+                            .status()
+                            .map(|s| s.success())
+                            .unwrap_or(false)
+                    });
 
-            // Check commands (must all succeed)
-            if pass && !dc.commands.is_empty() {
-                pass = dc.commands.iter().all(|cmd_str| {
-                    let parts: Vec<&str> = cmd_str.split_whitespace().collect();
-                    if parts.is_empty() {
-                        return false;
-                    }
-                    create_command(parts[0])
-                        .args(&parts[1..])
-                        .current_dir(project_dir)
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status()
-                        .map(|s| s.success())
-                        .unwrap_or(false)
-                });
+                let env_ok =
+                    commands_ok && dc.env_vars.iter().all(|var| std::env::var(var).is_ok());
+
+                env_ok
+                    && dc.content.iter().all(|cm| {
+                        let file_path = project_dir.join(&cm.file);
+                        std::fs::read_to_string(file_path)
+                            .map(|content| content.contains(&cm.contains))
+                            .unwrap_or(false)
+                    })
             }
-
-            // Check environment variables (all must be set)
-            if pass && !dc.env_vars.is_empty() {
-                pass = dc.env_vars.iter().all(|var| std::env::var(var).is_ok());
-            }
-
-            // Check content matches (all must match)
-            if pass && !dc.content.is_empty() {
-                pass = dc.content.iter().all(|cm| {
-                    let file_path = project_dir.join(&cm.file);
-                    std::fs::read_to_string(file_path)
-                        .map(|content| content.contains(&cm.contains))
-                        .unwrap_or(false)
-                });
-            }
-
-            pass
-        } else {
             // No enhanced config: use basic file detection only
-            self.config.detect(project_dir)
+            None => self.config.detect(project_dir),
         };
 
         if detected {
@@ -366,10 +392,15 @@ impl TestAdapter for ScriptTestAdapter {
             cmd.env(key, value);
         }
 
+        let _ = self.run_dir.set(working_dir);
+
         Ok(cmd)
     }
 
     fn parse_output(&self, stdout: &str, stderr: &str, exit_code: i32) -> TestRunResult {
+        if let Some(report) = self.read_report_file() {
+            return parse_script_output(&self.config.parser, &report, stderr, exit_code);
+        }
         parse_script_output(&self.config.parser, stdout, stderr, exit_code)
     }
 
@@ -546,18 +577,22 @@ fn parse_json_test(value: &serde_json::Value) -> Option<TestCase> {
 
 /// Parse JUnit XML output.
 fn parse_junit_output(stdout: &str, exit_code: i32) -> TestRunResult {
-    let mut suites = Vec::new();
-
-    // Find all <testsuite> blocks
-    for line in stdout.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("<testsuite")
-            && !trimmed.starts_with("<testsuites")
-            && let Some(suite) = parse_junit_suite_tag(trimmed, stdout)
-        {
-            suites.push(suite);
-        }
-    }
+    // Each <testsuite> owns only the <testcase> elements inside it. Runners
+    // that emit one suite per file (Playwright, jest-junit, surefire) would
+    // otherwise report every test once per suite.
+    let mut suites: Vec<TestSuite> = xml_elements(stdout, "testsuite")
+        .into_iter()
+        .filter_map(|(tag, body)| {
+            let tests = parse_junit_testcases(&body);
+            if tests.is_empty() {
+                return None;
+            }
+            Some(TestSuite {
+                name: extract_xml_attr(&tag, "name").unwrap_or_else(|| "tests".to_string()),
+                tests,
+            })
+        })
+        .collect();
 
     // If no suites found, try to parse <testcase> elements directly
     if suites.is_empty() {
@@ -581,82 +616,114 @@ fn parse_junit_output(stdout: &str, exit_code: i32) -> TestRunResult {
     }
 }
 
-fn parse_junit_suite_tag(tag: &str, full_output: &str) -> Option<TestSuite> {
-    let name = extract_xml_attr(tag, "name").unwrap_or_else(|| "tests".to_string());
-    let tests = parse_junit_testcases(full_output);
-    if tests.is_empty() {
-        return None;
-    }
-    Some(TestSuite { name, tests })
+fn parse_junit_testcases(xml: &str) -> Vec<TestCase> {
+    xml_elements(xml, "testcase")
+        .into_iter()
+        .map(|(tag, body)| {
+            let failure = xml_elements(&body, "failure")
+                .into_iter()
+                .chain(xml_elements(&body, "error"))
+                .next();
+
+            let (status, error) = match failure {
+                Some((tag, _)) => (
+                    TestStatus::Failed,
+                    Some(TestError {
+                        message: extract_xml_attr(&tag, "message")
+                            .unwrap_or_else(|| "Test failed".to_string()),
+                        location: None,
+                    }),
+                ),
+                None if !xml_elements(&body, "skipped").is_empty() => (TestStatus::Skipped, None),
+                None => (TestStatus::Passed, None),
+            };
+
+            TestCase {
+                name: extract_xml_attr(&tag, "name").unwrap_or_else(|| "unknown".to_string()),
+                status,
+                duration: extract_xml_attr(&tag, "time")
+                    .and_then(|t| t.parse::<f64>().ok())
+                    .map(duration_from_secs_safe)
+                    .unwrap_or(Duration::ZERO),
+                error,
+            }
+        })
+        .collect()
 }
 
-fn parse_junit_testcases(xml: &str) -> Vec<TestCase> {
-    let mut tests = Vec::new();
-    let lines: Vec<&str> = xml.lines().collect();
+/// Collect every `<name ...>` element in `xml` as `(open tag, inner body)`.
+///
+/// Scans by tag offset rather than by line so that single-line documents —
+/// what `pytest --junitxml` and most JUnit writers produce — parse the same as
+/// pretty-printed ones. Self-closing elements yield an empty body.
+fn xml_elements(xml: &str, name: &str) -> Vec<(String, String)> {
+    let open = format!("<{name}");
+    let close = format!("</{name}>");
+    let mut elements = Vec::new();
+    let mut cursor = 0;
 
-    let mut i = 0;
-    while i < lines.len() {
-        let trimmed = lines[i].trim();
-        if trimmed.starts_with("<testcase") {
-            let name = extract_xml_attr(trimmed, "name").unwrap_or_else(|| "unknown".to_string());
-            let time = extract_xml_attr(trimmed, "time")
-                .and_then(|t| t.parse::<f64>().ok())
-                .map(duration_from_secs_safe)
-                .unwrap_or(Duration::ZERO);
+    while let Some(offset) = xml[cursor..].find(&open) {
+        let start = cursor + offset;
+        let after_name = start + open.len();
 
-            // Check for failure/error/skipped in subsequent lines
-            let mut status = TestStatus::Passed;
-            let mut error = None;
-
-            if trimmed.ends_with("/>") {
-                // Self-closing, check for nested skipped/failure check
-                if trimmed.contains("<skipped") {
-                    status = TestStatus::Skipped;
-                }
-            } else {
-                // Look at following lines until </testcase>
-                let mut j = i + 1;
-                while j < lines.len() {
-                    let inner = lines[j].trim();
-                    if inner.starts_with("</testcase") {
-                        break;
-                    }
-                    if inner.starts_with("<failure") || inner.starts_with("<error") {
-                        status = TestStatus::Failed;
-                        let message = extract_xml_attr(inner, "message")
-                            .unwrap_or_else(|| "Test failed".to_string());
-                        error = Some(TestError {
-                            message,
-                            location: None,
-                        });
-                    }
-                    if inner.starts_with("<skipped") {
-                        status = TestStatus::Skipped;
-                    }
-                    j += 1;
-                }
-            }
-
-            tests.push(TestCase {
-                name,
-                status,
-                duration: time,
-                error,
-            });
+        // Reject prefix matches: `<testsuites` is not a `<testsuite`.
+        if !matches!(xml[after_name..].chars().next(), Some(c) if c.is_whitespace() || c == '>' || c == '/')
+        {
+            cursor = after_name;
+            continue;
         }
-        i += 1;
+
+        let Some(offset) = xml[after_name..].find('>') else {
+            break;
+        };
+        let tag_end = after_name + offset;
+        let tag = xml[start..=tag_end].to_string();
+
+        if tag.ends_with("/>") {
+            elements.push((tag, String::new()));
+            cursor = tag_end + 1;
+            continue;
+        }
+
+        let body_start = tag_end + 1;
+        let (body, next) = match xml[body_start..].find(&close) {
+            Some(offset) => (
+                xml[body_start..body_start + offset].to_string(),
+                body_start + offset + close.len(),
+            ),
+            None => (xml[body_start..].to_string(), xml.len()),
+        };
+        elements.push((tag, body));
+        cursor = next;
     }
 
-    tests
+    elements
 }
 
 /// Extract an XML attribute value from an element tag.
 fn extract_xml_attr(tag: &str, attr: &str) -> Option<String> {
     let search = format!("{attr}=\"");
-    let start = tag.find(&search)? + search.len();
-    let rest = &tag[start..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
+    let mut from = 0;
+
+    while let Some(offset) = tag[from..].find(&search) {
+        let start = from + offset;
+        // `name=` must not match the tail of `classname=`.
+        let delimited = start == 0
+            || tag[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_whitespace() || c == '<');
+        let value_start = start + search.len();
+
+        if delimited {
+            let rest = &tag[value_start..];
+            let end = rest.find('"')?;
+            return Some(rest[..end].to_string());
+        }
+        from = value_start;
+    }
+
+    None
 }
 
 /// Parse TAP (Test Anything Protocol) output.
@@ -1437,6 +1504,84 @@ mod tests {
         assert_eq!(extract_xml_attr("<test>", "name"), None);
     }
 
+    #[test]
+    fn xml_attr_ignores_a_longer_attribute_with_the_same_suffix() {
+        assert_eq!(
+            extract_xml_attr(r#"<testcase classname="Foo" name="bar">"#, "name"),
+            Some("bar".into())
+        );
+    }
+
+    // ─── Opt-in adapters & report files ─────────────────────────────────
+
+    fn custom_config(name: &str, command: &str) -> crate::config::CustomAdapterConfig {
+        toml::from_str(&format!(
+            "name = \"{name}\"\ncommand = \"{command}\"\noutput = \"junit\"\n"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn adapter_without_detect_rules_never_auto_detects() {
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = ScriptTestAdapter::from_custom_config(&custom_config("e2e", "echo"));
+        assert!(adapter.detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn adapter_with_content_only_rule_detects() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Makefile"), "test:\n\techo hi\n").unwrap();
+
+        let cfg: crate::config::CustomAdapterConfig = toml::from_str(
+            r#"
+name = "make-test"
+command = "make test"
+[[detect.content]]
+file = "Makefile"
+contains = "test:"
+"#,
+        )
+        .unwrap();
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        assert!(adapter.detect(dir.path()).is_some());
+    }
+
+    #[test]
+    fn report_file_is_parsed_instead_of_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("junit.xml"),
+            r#"<testsuite name="e2e"><testcase name="login" time="0.5"/></testsuite>"#,
+        )
+        .unwrap();
+
+        let mut cfg = custom_config("e2e", "echo");
+        cfg.report_file = Some("junit.xml".into());
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        adapter.build_command(dir.path(), &[]).unwrap();
+
+        let result = adapter.parse_output("Running 1 test using 1 worker", "", 0);
+        assert_eq!(result.total_passed(), 1);
+        assert_eq!(result.suites[0].tests[0].name, "login");
+    }
+
+    #[test]
+    fn missing_report_file_falls_back_to_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = custom_config("e2e", "echo");
+        cfg.report_file = Some("never-written.xml".into());
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+        adapter.build_command(dir.path(), &[]).unwrap();
+
+        let result = adapter.parse_output(
+            r#"<testsuite name="from-stdout"><testcase name="t" time="0.1"/></testsuite>"#,
+            "",
+            0,
+        );
+        assert_eq!(result.suites[0].name, "from-stdout");
+    }
+
     // ─── Fallback Result Tests ──────────────────────────────────────────
 
     #[test]
@@ -1780,8 +1925,33 @@ mod tests {
   </testsuite>
 </testsuites>"#;
         let result = parse_junit_output(xml, 0);
-        // Note: current parser finds testcases regardless of suite nesting
-        assert!(result.total_tests() >= 2);
+        // Each suite owns only its own testcases — no cross-suite duplication.
+        assert_eq!(result.total_tests(), 2);
+        assert_eq!(result.suites.len(), 2);
+        assert_eq!(result.suites[0].name, "s1");
+        assert_eq!(result.suites[0].tests[0].name, "t1");
+        assert_eq!(result.suites[1].name, "s2");
+        assert_eq!(result.suites[1].tests[0].name, "t2");
+    }
+
+    #[test]
+    fn parse_junit_single_line_document() {
+        // What pytest --junitxml and most JUnit writers actually emit.
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" tests="2"><testcase classname="test_a" name="passes" time="0.01"/><testcase classname="test_a" name="fails" time="0.02"><failure message="assert 1 == 2">trace</failure></testcase></testsuite></testsuites>"#;
+        let result = parse_junit_output(xml, 1);
+        assert_eq!(result.total_tests(), 2);
+        assert_eq!(result.total_failed(), 1);
+        assert_eq!(result.suites[0].name, "pytest");
+        assert_eq!(result.suites[0].tests[1].name, "fails");
+    }
+
+    #[test]
+    fn parse_junit_reads_name_not_classname() {
+        // Maven surefire puts classname first; `name=` must not match the tail
+        // of `classname=`.
+        let xml = r#"<testsuite name="s"><testcase classname="com.example.Foo" name="the_test" time="0.5"/></testsuite>"#;
+        let result = parse_junit_output(xml, 0);
+        assert_eq!(result.suites[0].tests[0].name, "the_test");
     }
 
     #[test]
@@ -2148,6 +2318,7 @@ mod tests {
             confidence: 0.7,
             check: Some("bazel --version".into()),
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2178,6 +2349,7 @@ mod tests {
             confidence: 0.5,
             check: None,
             working_dir: Some("src".into()),
+            report_file: None,
             env,
         };
 
@@ -2209,6 +2381,7 @@ mod tests {
             confidence: 0.6,
             check: None,
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2240,6 +2413,7 @@ mod tests {
             confidence: 0.6,
             check: None,
             working_dir: None,
+            report_file: None,
             env: std::collections::HashMap::new(),
         };
 

--- a/src/plugin/script_adapter.rs
+++ b/src/plugin/script_adapter.rs
@@ -211,7 +211,18 @@ impl ScriptTestAdapter {
         let detect_file = cfg.detect.files.first().cloned().unwrap_or_default();
 
         // Map output parser string → OutputParser enum
-        let parser = parse_output_parser_str(&cfg.output);
+        let parser = match cfg.pattern.as_ref() {
+            Some(p) if matches!(cfg.output.to_lowercase().as_str(), "pattern" | "regex") => {
+                OutputParser::Regex(RegexParserConfig {
+                    pass_pattern: p.pass.clone(),
+                    fail_pattern: p.fail.clone(),
+                    skip_pattern: p.skip.clone(),
+                    name_group: p.name_group.unwrap_or(1),
+                    duration_group: p.duration_group,
+                })
+            }
+            _ => parse_output_parser_str(&cfg.output),
+        };
 
         // Map env HashMap → Vec<(String, String)>
         let env: Vec<(String, String)> = cfg
@@ -1582,6 +1593,27 @@ contains = "test:"
         assert_eq!(result.suites[0].name, "from-stdout");
     }
 
+    #[test]
+    fn pattern_parser_is_reachable_from_config() {
+        let cfg: crate::config::CustomAdapterConfig = toml::from_str(
+            r#"
+name = "bats"
+command = "bats"
+output = "pattern"
+[pattern]
+pass = "ok (.*)"
+fail = "not ok (.*)"
+"#,
+        )
+        .unwrap();
+        let adapter = ScriptTestAdapter::from_custom_config(&cfg);
+
+        let result = adapter.parse_output("ok validates input\nnot ok rejects junk\n", "", 1);
+        assert_eq!(result.total_passed(), 1);
+        assert_eq!(result.total_failed(), 1);
+        assert_eq!(result.suites[0].tests[0].name, "validates input");
+    }
+
     // ─── Fallback Result Tests ──────────────────────────────────────────
 
     #[test]
@@ -2319,6 +2351,7 @@ contains = "test:"
             check: Some("bazel --version".into()),
             working_dir: None,
             report_file: None,
+            pattern: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2350,6 +2383,7 @@ contains = "test:"
             check: None,
             working_dir: Some("src".into()),
             report_file: None,
+            pattern: None,
             env,
         };
 
@@ -2382,6 +2416,7 @@ contains = "test:"
             check: None,
             working_dir: None,
             report_file: None,
+            pattern: None,
             env: std::collections::HashMap::new(),
         };
 
@@ -2414,6 +2449,7 @@ contains = "test:"
             check: None,
             working_dir: None,
             report_file: None,
+            pattern: None,
             env: std::collections::HashMap::new(),
         };
 

--- a/tests/integration/custom_adapter.rs
+++ b/tests/integration/custom_adapter.rs
@@ -54,3 +54,144 @@ fn run_without_framework_errors_cleanly() {
         "Should show helpful error message"
     );
 }
+
+/// A custom adapter with no detect rules is opt-in: invisible to detection,
+/// runnable by name. This is how a second suite (e2e, smoke, contract tests)
+/// lives beside the project's default one.
+#[test]
+fn opt_in_adapter_runs_only_when_named() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+[[custom_adapter]]
+name = "e2e"
+command = "echo"
+args = ["PASS login_flow"]
+output = "lines"
+"#,
+    )
+    .unwrap();
+
+    let detected = Command::cargo_bin("testx")
+        .unwrap()
+        .args(["detect", "--path", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&detected.stdout).contains("No test framework detected"),
+        "opt-in adapter must not hijack detection"
+    );
+
+    let run = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "e2e",
+        ])
+        .output()
+        .unwrap();
+    assert!(run.status.success());
+    assert!(String::from_utf8_lossy(&run.stdout).contains("login_flow"));
+}
+
+#[test]
+fn unknown_adapter_name_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("README.md"), "# Empty").unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "cobol",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!result.status.success());
+    assert!(String::from_utf8_lossy(&result.stderr).contains("Unknown adapter 'cobol'"));
+}
+
+/// `--adapter` beats `adapter = ` in testx.toml, so a repo can pin its default
+/// suite and still run the other one on demand.
+#[test]
+fn cli_adapter_overrides_config_adapter() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"fake\"").unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+adapter = "Rust"
+
+[[custom_adapter]]
+name = "smoke"
+command = "echo"
+args = ["PASS smoke_check"]
+output = "lines"
+"#,
+    )
+    .unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "smoke",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(result.status.success());
+    assert!(String::from_utf8_lossy(&result.stdout).contains("smoke_check"));
+}
+
+/// Runners that only write machine-readable results to a file (pytest
+/// --junitxml, jest-junit, PLAYWRIGHT_JUNIT_OUTPUT_NAME) are parsed from it.
+#[test]
+fn report_file_is_parsed_instead_of_stdout() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("junit.xml"),
+        r#"<testsuites><testsuite name="e2e"><testcase name="checkout" time="1.5"/><testcase name="refund" time="0.5"><failure message="timeout"/></testcase></testsuite></testsuites>"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("testx.toml"),
+        r#"
+[[custom_adapter]]
+name = "e2e"
+command = "echo"
+args = ["Running 2 tests using 1 worker"]
+output = "junit"
+report_file = "junit.xml"
+"#,
+    )
+    .unwrap();
+
+    let result = Command::cargo_bin("testx")
+        .unwrap()
+        .args([
+            "run",
+            "--path",
+            dir.path().to_str().unwrap(),
+            "--adapter",
+            "e2e",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(!result.status.success(), "one testcase failed: {stdout}");
+    assert!(stdout.contains("checkout"), "{stdout}");
+    assert!(stdout.contains("timeout"), "{stdout}");
+}


### PR DESCRIPTION
Audited every adapter against real runner output. Four findings were testx reporting something untrue.

- **Python** — `-v` was only added when no extra args were passed, so `testx -- --cov` ran pytest in dot mode and the summary fallback invented names (`test_1`, `failed_test_2`). A real 581-test suite came back as one suite called `tests`; it now reports 61 suites with real names.
- **Go** — the same branch also dropped `./...`, so `testx -- -race` quietly tested only the root package.
- **Python** — a bare `pyproject.toml` was enough to claim a project and run `unittest` over a library with no tests. Detection now needs a test dir, test files or a test config.
- **Python** — uv/Poetry workspace members ran with `unittest` because the pytest config lives at the workspace root. testx now walks up for it, the way pytest resolves its rootdir.

Also: `unittest` verbose output is parsed per test, a `package.json` with a `test` script but no known framework runs via `npm test` (covers `node --test`, tap, uvu), and `output = "pattern"` reaches the line parser that already existed with no way to configure it.

No new language adapters — I can't run Swift or Dart here, and shipping parsers I can't exercise against real output is how these bugs got in.

`cargo test` 1129 + 33 + 25 green, clippy and fmt clean. Targets #6 because the pattern config sits next to `report_file` in the same struct.
